### PR TITLE
Gazebo controllers cannot launch due to namespace issue

### DIFF
--- a/iiwa_description/urdf/iiwa.gazebo.xacro
+++ b/iiwa_description/urdf/iiwa.gazebo.xacro
@@ -6,8 +6,8 @@
     
     <!-- Load Gazebo lib and set the robot namespace -->
     <gazebo>
-      <plugin name="gazebo_ros_controller" filename="libgazebo_ros_control.so">
-	<robotNamespace>/${robot_name}</robotNamespace>
+      <plugin name="gazebo_ros_control" filename="libgazebo_ros_control.so">
+        <robotNamespace>/${robot_name}</robotNamespace>
       </plugin>
     </gazebo>
 

--- a/iiwa_gazebo/launch/iiwa_gazebo.launch
+++ b/iiwa_gazebo/launch/iiwa_gazebo.launch
@@ -36,7 +36,7 @@
     </group>
     
     <!-- Spawn controllers - it uses an Effort Controller for each joint -->
-    <group unless="$(arg trajectory)">
+    <group ns="$(arg robot_name)" unless="$(arg trajectory)">
         
         <include file="$(find iiwa_control)/launch/iiwa_control.launch">
             <arg name="hardware_interface" value="$(arg hardware_interface)" />

--- a/iiwa_gazebo/launch/iiwa_gazebo.launch
+++ b/iiwa_gazebo/launch/iiwa_gazebo.launch
@@ -24,7 +24,7 @@
     </include>
     
     <!-- Spawn controllers - it uses a JointTrajectoryController -->
-    <group if="$(arg trajectory)">
+    <group  ns="$(arg robot_name)" if="$(arg trajectory)">
         
         <include file="$(find iiwa_control)/launch/iiwa_control.launch">
             <arg name="hardware_interface" value="$(arg hardware_interface)" />


### PR DESCRIPTION
Fixed an issue in which the controllers would not come up when running "iiwa_gazebo.launch" because the namespaces for the controller spawners did not match the namespace in the URDF.