### PR TITLE
no more namespace in gazebo call in moveit planning execution

### DIFF
--- a/iiwa_moveit/launch/moveit_planning_execution.launch
+++ b/iiwa_moveit/launch/moveit_planning_execution.launch
@@ -20,7 +20,7 @@
     <remap from="/get_planning_scene" to="/$(arg robot_name)/get_planning_scene" /> 
     
     <!-- Run the robot within a Gazebo simulation. -->
-    <group ns="$(arg robot_name)" if="$(arg sim)">
+    <group if="$(arg sim)">
         
         <!-- Load Gazebo with given values -->
         <include file="$(find iiwa_gazebo)/launch/iiwa_gazebo.launch">


### PR DESCRIPTION
iiwa_gazebo was not working when launched independently before; moving the namespace calls to around the controller definitions fixed this but broke the moveit planning exection file. Fixing this was a matter of removing the namespace  from the sim call.