### PR TITLE
ntp_with_host set to false

### DIFF
--- a/iiwa_ros_java/src/de/tum/in/camp/kuka/ros/config.txt
+++ b/iiwa_ros_java/src/de/tum/in/camp/kuka/ros/config.txt
@@ -1,4 +1,4 @@
 robot_name: iiwa
 master_ip: 160.69.69.100
 master_port: 11311
-ntp_with_host: true
+ntp_with_host: false


### PR DESCRIPTION
default true was causing the java application to hang without a ntp server on the linux side.
Fixes #13 