### PR TITLE
Docker for Java message generation

### DIFF
--- a/iiwa_msgs/.gitignore
+++ b/iiwa_msgs/.gitignore
@@ -1,0 +1,1 @@
+rosjava_messages

--- a/iiwa_msgs/CMakeLists.txt
+++ b/iiwa_msgs/CMakeLists.txt
@@ -3,11 +3,9 @@ project(iiwa_msgs)
 
 find_package(catkin REQUIRED COMPONENTS
     actionlib_msgs
-    message_generation
-    cmake_modules
     geometry_msgs
-    std_msgs
-)
+    message_generation
+    std_msgs)
 
 # Declare the message files to be built
 add_message_files(DIRECTORY msg)
@@ -15,6 +13,6 @@ add_service_files(DIRECTORY srv)
 add_action_files(DIRECTORY action)
 
 # Actually generate the language-specific message and service files
-generate_messages(DEPENDENCIES std_msgs geometry_msgs actionlib_msgs)
+generate_messages(DEPENDENCIES actionlib_msgs geometry_msgs std_msgs)
 
-catkin_package(CATKIN_DEPENDS message_runtime std_msgs geometry_msgs) 
+catkin_package(CATKIN_DEPENDS actionlib_msgs geometry_msgs message_runtime std_msgs ) 

--- a/iiwa_msgs/Dockerfile
+++ b/iiwa_msgs/Dockerfile
@@ -1,0 +1,26 @@
+FROM ros:kinetic-ros-base
+
+# use bash to be able to source the ros files
+SHELL ["/bin/bash", "-c"]
+
+# upgrade ros packages
+RUN apt-get update && \
+    apt-get install --only-upgrade ros-kinetic-* -y && \
+    apt-get install python-wstool -y
+
+# setup catkin_ws for java 6 message generation  
+RUN mkdir -p /catkin_ws
+WORKDIR /catkin_ws
+RUN source /ros_entrypoint.sh && \
+    wstool init src && \
+    wstool set -y -t src genjava --git https://github.com/Tuebel/genjava.git --version=kinetic_java6 && \
+    wstool update -t src && \
+    rosdep install --from-paths src --ignore-src -r -y && \
+    catkin_make
+
+# add and generate the message.
+ADD . /catkin_ws/src/iiwa_msgs
+
+# disbale message generation for all but java if using catkin_make.
+# note that the jars generated via catkin_make seem to be empty
+# ENV ROS_LANG_DISABLE "gencpp;geneus;genlisp;gennodejs;genpy"

--- a/iiwa_msgs/README.md
+++ b/iiwa_msgs/README.md
@@ -1,0 +1,27 @@
+# Message Generation
+
+# CPP, Python, ...
+These messages should be automatically generated when calling `catkin_make` or `catkin build` in the workspace.
+
+## Java Messages - Docker
+Since genjava has only support for Kinetic and earlier versions of ROS, a DOCKERFILE has been written.
+Specifically, we use a fork of the genjava package which will generate the messages for Java 6, which is the latest Sunrise supports.
+This file can be used to setup the build environment on any system that supports Docker.
+To build the DOCKERFILE simply **navigate to this directory** in a shell and call:
+```bash
+docker build --tag iiwa_msgs:latest . 
+```
+
+Now, the messages can be generated and copied to the host.
+```bash
+docker run --name iiwa_msgs -it iiwa_msgs:latest /bin/bash -c \
+  "source devel/setup.bash && \
+  genjava_message_artifacts --verbose -p iiwa_msgs actionlib_msgs geometry_msgs std_msgs"
+docker cp iiwa_msgs:/catkin_ws/devel/share/maven/org/ros/rosjava_messages rosjava_messages
+docker rm iiwa_msgs
+```
+
+The generated files will end up in a directory called `rosjava_messages` in your current directory.
+In the leaf directories you will find the .jar files which can be copied to `iiwa_ros_java/ROSJavaLib`.
+Make sure to replace all four files since they depend on each other.
+In the Sunrise Workbench, refresh the files view and edit the build path: remove the old versions and add the new versions from ROSJavaLib.

--- a/iiwa_msgs/package.xml
+++ b/iiwa_msgs/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <package format="2">
-<name>iiwa_msgs</name>
+  <name>iiwa_msgs</name>
   <version>2.3.1</version>
   <description>ROS Messages to communicate with a KUKA LBR IIWA Robot</description>
   <author email="salvo.virga@tum.de">Salvo Virga</author>
@@ -11,8 +11,10 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <depend>actionlib_msgs</depend>
-  <depend>message_generation</depend>
-  <depend>message_runtime</depend>
   <depend>std_msgs</depend>
   <depend>geometry_msgs</depend>
+
+  <build_depend>message_generation</build_depend>
+
+  <exec_depend>message_runtime</exec_depend>
 </package>


### PR DESCRIPTION
Hi and thanks for your awesome work on this stack!

Right now we are working on a stack for the LBR Med which is largely based on this one. We have made some modifications to increase the compatibility to our project partners who are using the Franka Emika.

In this context we had to modify some messages. Ssince I am on Ubuntu 18.04 and Melodic, I had no way of generating the messages, as genjava is only support up until Kinetic. However, I was able to generate the messages in a Docker container which is based on ROS Kinetic. I have deployed the jar files to the robot without any problems.

Have a look at the included README file for instructions on how to use the Dockerfile.